### PR TITLE
The std.stream of Phobos will be deprecated in the future.

### DIFF
--- a/src/org/eclipse/swt/snippets/Snippet288.d
+++ b/src/org/eclipse/swt/snippets/Snippet288.d
@@ -40,7 +40,6 @@ version(Tango){
     import tango.core.Exception;
 } else { // Phobos
     import std.path;
-    import std.stream;
     import std.stdio;
     import std.conv;
     import core.exception;


### PR DESCRIPTION
This one line is unnecessary code to begin with.